### PR TITLE
Missing `await` in the Infinite scroll section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1513,7 +1513,7 @@ Then, open `pages/blog.js` and make the following changes:
 3. Modify the `wpapi` call in `getInitialProps` to load page 1 with 10 items per page:
 
    ```js
-   const posts = api.posts().perPage(PER_PAGE).page(1).embed();
+   const posts = await api.posts().perPage(PER_PAGE).page(1).embed();
    ```
 
 4. Since this component will become stateful, we will render posts from the state. Add a


### PR DESCRIPTION
The `wpapi` call in `getInitialProps` was missing the `await`, causing an error while trying to fetch API's data.